### PR TITLE
Add support for custom package names

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -17,6 +17,7 @@ beforeEach(() => {
     INPUT_OWNER: "mheap",
     INPUT_REPO: "demo-cli",
     INPUT_CLI_NAME: "demo",
+    INPUT_PACKAGE_NAME_TEMPLATE: "{{name}}_{{version}}_{{os}}_{{arch}}",
   });
   restoreTest = () => {};
 


### PR DESCRIPTION
`goreleaser` allows you to customise the name of your package. The default is `{{name}}_{{os}}_{{arch}}` but some projects like to add the version number too e.g. `{{name}}_{{version}}_{{os}}_{{arch}}`